### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: python
 cache: pip
 matrix:
   allow_failures:
-    - python: 3.7
+    - python: 2.7
   include:
     - python: 2.7
-    #- python: 3.4
     #- python: 3.5
     #- python: 3.6
     - python: 3.7
@@ -16,9 +15,9 @@ install:
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --builtins="gdb,offset,slot"
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --builtins="gdb,offset,slot"
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - true  # add other tests here
 notifications:

--- a/tools/avg.py
+++ b/tools/avg.py
@@ -22,6 +22,7 @@ will output
   [10/10] [default]              : avg  22,885.80 stddev   1,941.80 ( 17,584.00 -  24,266.00) Kps
 """
 
+from __future__ import print_function
 import argparse
 import math
 import re

--- a/tools/gdb-v8-support.py
+++ b/tools/gdb-v8-support.py
@@ -32,6 +32,7 @@ import os
 import subprocess
 import time
 
+import gdb
 
 kSmiTag = 0
 kSmiTagSize = 1

--- a/tools/gen-inlining-tests.py
+++ b/tools/gen-inlining-tests.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-
+from __future__ import print_function
 from collections import namedtuple
 import textwrap
 import sys

--- a/tools/grokdump.py
+++ b/tools/grokdump.py
@@ -27,6 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# flake8: noqa  # https://bugs.chromium.org/p/v8/issues/detail?id=8784
+
 from __future__ import print_function
 from __future__ import absolute_import
 import BaseHTTPServer

--- a/tools/locs.py
+++ b/tools/locs.py
@@ -7,6 +7,7 @@
   Consult --help for more information.
 """
 
+from __future__ import print_function
 import argparse
 import json
 import os


### PR DESCRIPTION
Fixes the following Python 2 syntax errors:
```
$ flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --builtins="gdb,offset,slot"
./tools/locs.py:128:25: E999 SyntaxError: invalid syntax
        build_dir), file=sys.stderr)
                        ^
./tools/avg.py:198:57: E999 SyntaxError: invalid syntax
    print("{:<{}}".format("", self.last_status_len), end="\r")
                                                        ^
./tools/gen-inlining-tests.py:457:14: E999 SyntaxError: invalid syntax
  return print(*args, file=FILE)
             ^
3     E999 SyntaxError: invalid syntax
3
```
Also:
* __import gdb__ for access to [__gdb-tools__](https://pypi.org/project/gdb-tools/)
* Add __# flake8: noqa__ to ./tools/grokdump.py to suppress _undefined name_ issues.
    * https://bugs.chromium.org/p/v8/issues/detail?id=8784