### PR TITLE
placate PyLint

### DIFF
--- a/tools/mb/mb.py
+++ b/tools/mb/mb.py
@@ -39,9 +39,9 @@ sys.path = [os.path.join(CHROMIUM_SRC_DIR, 'build')] + sys.path
 import gn_helpers
 
 try:
-  cmp             # Python 2
-except NameError:
-  def cmp(x, y):  # Python 3
+  cmp              # Python 2
+except NameError:  # Python 3 
+  def cmp(x, y):   # pylint: disable=redefined-builtin
     return (x > y) - (x < y)
 
 


### PR DESCRIPTION
The linter directive __#  pylint: disable=redefined-builtin__ should solve the issue raised at:
* https://ci.chromium.org/p/v8/builders/luci.v8.try/v8_presubmit/b8922343873600373648